### PR TITLE
Fix Docker Hub URL

### DIFF
--- a/INSTALL_EXTRAS.md
+++ b/INSTALL_EXTRAS.md
@@ -4,7 +4,7 @@ While using the full power of Evaluator is easier with some basic proficency wit
 
 # Docker
 
-The simplest method applicable to most users is the corresponding [evaluator-docker](https://github.com/davidski/evaluator-docker) project. This Dockerfile (and the corresponding pre-built image on [Docker Hub](https://hub.docker.com/r/davidski/evaluator)) is the fastest and surest means of getting started with Evaluator.
+The simplest method applicable to most users is the corresponding [evaluator-docker](https://github.com/davidski/evaluator-docker) project. This Dockerfile (and the corresponding pre-built image on [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker/)) is the fastest and surest means of getting started with Evaluator.
 
 # MacOS
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker/).
 
 ## Usage
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator/).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker/).
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator/).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
 
 Usage
 -----

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,7 @@
 <span class="co"># Optionally, to install the development verison from GitHub</span>
 <span class="co"># install.pacakges("devtools")</span>
 devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/devtools/topics/install_github">install_github</a></span>(<span class="st">"davidski/evaluator"</span>)</code></pre></div>
-<p>Optionally, a prototype Docker image is available on the <a href="https://hub.docker.com/r/davidski/evaluator-docker//">Docker Hub</a>.</p>
+<p>Optionally, a prototype Docker image is available on the <a href="https://hub.docker.com/r/davidski/evaluator-docker/">Docker Hub</a>.</p>
 </div>
 <div id="usage" class="section level2">
 <h2 class="hasAnchor">

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,7 @@
 <span class="co"># Optionally, to install the development verison from GitHub</span>
 <span class="co"># install.pacakges("devtools")</span>
 devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/devtools/topics/install_github">install_github</a></span>(<span class="st">"davidski/evaluator"</span>)</code></pre></div>
-<p>Optionally, a prototype Docker image is available on the <a href="https://hub.docker.com/r/davidski/evaluator/">Docker Hub</a>.</p>
+<p>Optionally, a prototype Docker image is available on the <a href="https://hub.docker.com/r/davidski/evaluator-docker//">Docker Hub</a>.</p>
 </div>
 <div id="usage" class="section level2">
 <h2 class="hasAnchor">

--- a/index.Rmd
+++ b/index.Rmd
@@ -47,7 +47,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator/).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
 
 ## Usage
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -47,7 +47,7 @@ install.packages("evaluator")
 devtools::install_github("davidski/evaluator")
 ```
 
-Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker//).
+Optionally, a prototype Docker image is available on the [Docker Hub](https://hub.docker.com/r/davidski/evaluator-docker/).
 
 ## Usage
 


### PR DESCRIPTION
The current URL for the docker hub image is invalid (404 error). Fixed in all locations.