### PR TITLE
Effectively calling as_tibble()

### DIFF
--- a/R/tidyrisk_scenario.R
+++ b/R/tidyrisk_scenario.R
@@ -108,7 +108,8 @@ print.tidyrisk_scenario <- function(x, ...) {
 as_tibble.tidyrisk_scenario <- function(x, ...) {
   cli::cat_line("# Scenario model: ", x$model)
   purrr::map_depth(x$parameters, .depth = 1, dplyr::bind_rows, .id = "id") %>%
-    dplyr::bind_rows(.id = "openfair_factor")
+    dplyr::bind_rows(.id = "openfair_factor") %>%
+    tibble::as_tibble()
 }
 
 #' @rdname as_tibble.tidyrisk_scenario


### PR DESCRIPTION
In the about to be released `dplyr` version, `bind_rows()` returns a data frame in that case. If you want a tibble, you must explicitely make it a tibble. 

We plan to release `dplyr` this week. 