### PR TITLE
Remove the extra backtick in chunk header

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-pandoc@v1
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
         run: |

--- a/inst/rmd/risk_dashboard.Rmd
+++ b/inst/rmd/risk_dashboard.Rmd
@@ -69,7 +69,7 @@ Value Boxes
 
 ### Aggregate Risk
 
-````{r var_valuebox}
+```{r var_valuebox}
 agg_risk <- quantile(iteration_summary$ale_sum, 0.95)
 flexdashboard::valueBox(dollar_millions(agg_risk), icon = "glyphicon-eye-open",
          caption = "Aggregate 95% Value at Risk",


### PR DESCRIPTION
This fixes the current CRAN check failures: https://cran.r-project.org/web/checks/check_results_evaluator.html

With the latest version of **knitr**, the numbers of backticks in chunk header and footer must match, which means you can no longer start a code chunk by four backticks but try to end it with three.

Apologies for the breaking change, and hope this could be merged and released soon. Thanks a lot!